### PR TITLE
Fix typos across documentation and source files

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -178,7 +178,7 @@ It's the way to protect your work from adventurous developers.
 
 .. note::
 
-   TOOD: Write a workflow how to add a test.
+   TODO: Write a workflow how to add a test.
 
 Include documentation about your PR
 """""""""""""""""""""""""""""""""""

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Examples:
     impactx input_fodo.in
 
   In the current working directory, there is a file "input_fodo.in" and the
-  "impactx" executable. We want to voerwrite the segment length of the beamline
+  "impactx" executable. We want to overwrite the segment length of the beamline
   element "quad1" that is already defined in it. We also want to change the
   radius of curvature of the bending magnet "sbend1" to a different value than
   in the file "input_fodo.in".

--- a/docs/source/install/users.rst
+++ b/docs/source/install/users.rst
@@ -160,6 +160,6 @@ Tips for macOS Users
    If you find entries in ``bin/``, ``lib/`` et al. that look like you manually installed MPI, HDF5 or other software in the past, then remove those files first.
 
    If you find software such as MPI in the same directories that are shown as symbolic links then it is likely you `brew installed <https://brew.sh/>`__ software before.
-   If you are trying annother package manager than ``brew``, run `brew unlink ... <https://docs.brew.sh/Tips-N%27-Tricks#quickly-remove-something-from-usrlocal>`__ on such packages first to avoid software incompatibilities.
+   If you are trying another package manager than ``brew``, run `brew unlink ... <https://docs.brew.sh/Tips-N%27-Tricks#quickly-remove-something-from-usrlocal>`__ on such packages first to avoid software incompatibilities.
 
 See also: A. Huebl, `Working With Multiple Package Managers <https://collegeville.github.io/CW20/WorkshopResources/WhitePapers/huebl-working-with-multiple-pkg-mgrs.pdf>`__, `Collegeville Workshop (CW20) <https://collegeville.github.io/CW20/>`_, 2020

--- a/docs/source/usage/parameters.rst
+++ b/docs/source/usage/parameters.rst
@@ -366,7 +366,7 @@ The internal tracking methods used by ImpactX are symplectic.  However, if a use
 This element requires these additional parameters:
 
 * ``<element_name>.R(i,j)`` (``float``, ...) matrix entries
-  a 1-indexed, 6x6, linear transport map to multiply with the the phase space vector :math:`(x,p_x,y,p_y,t,p_t)`.
+  a 1-indexed, 6x6, linear transport map to multiply with the phase space vector :math:`(x,p_x,y,p_y,t,p_t)`.
 * ``<element_name>.ds`` (``float``, in meters) length associated with a user-defined linear element (defaults to 0)
 * ``<element_name>.dx`` (``float``, in meters) horizontal translation error
 * ``<element_name>.dy`` (``float``, in meters) vertical translation error

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -218,7 +218,7 @@ Collective Effects & Overall Simulation Parameters
    .. py:method:: init_envelope(ref, distr, intensity=None)
 
       Envelope tracking mode:
-      Create a 6x6 covariance matrix from a distribution and then initialize the the simulation for envelope tracking relative to a reference particle.
+      Create a 6x6 covariance matrix from a distribution and then initialize the simulation for envelope tracking relative to a reference particle.
 
       :param ref: the reference particle (object from :py:class:`impactx.RefPart`)
       :param distr: distribution function (object from :py:mod:`impactx.distribution`)
@@ -707,7 +707,7 @@ This module provides elements and methods for the accelerator lattice.
    The internal tracking methods used by ImpactX are symplectic.  However, if a user-defined linear map :math:`R` is provided, it is
    up to the user to ensure that the matrix :math:`R` is symplectic.  Otherwise, this condition may be violated.
 
-   :param R: a linear transport map to multiply with the the phase space vector :math:`(x,px,y,py,t,pt)`.
+   :param R: a linear transport map to multiply with the phase space vector :math:`(x,px,y,py,t,pt)`.
    :param ds: length associated with a user-defined linear element (defaults to 0), in m
    :param dx: horizontal translation error in m
    :param dy: vertical translation error in m

--- a/examples/initialize_from_array/README.rst
+++ b/examples/initialize_from_array/README.rst
@@ -8,7 +8,7 @@ Initialize a Beam from Arrays
 
    This example is an early draft of this workflow and will be simplified in future versions of ImpactX, adding direct support for NumPy and CuPy arrays.
 
-This example demonstrates how a beam can be initalized in ImpactX from array-like structures.
+This example demonstrates how a beam can be initialized in ImpactX from array-like structures.
 This allows various applications of interest,
 such as using a beam from a different simulation,
 initializing a beam from file,

--- a/src/elements/Buncher.H
+++ b/src/elements/Buncher.H
@@ -115,7 +115,7 @@ namespace impactx::elements
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
 
-            // intialize output values of momenta
+            // initialize output values of momenta
             amrex::ParticleReal pxout = px;
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal ptout = pt;

--- a/src/elements/ChrPlasmaLens.H
+++ b/src/elements/ChrPlasmaLens.H
@@ -146,7 +146,7 @@ namespace impactx::elements
             amrex::ParticleReal xout = x;
             amrex::ParticleReal yout = y;
 
-            // intialize output values of momenta
+            // initialize output values of momenta
             amrex::ParticleReal pxout = px;
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal const ptout = pt;

--- a/src/elements/ChrQuad.H
+++ b/src/elements/ChrQuad.H
@@ -153,7 +153,7 @@ namespace impactx::elements
             // chromatic dependence on delta is included
             amrex::ParticleReal const omega = std::sqrt(std::abs(m_g)/delta1);
 
-            // intialize output values of momenta
+            // initialize output values of momenta
             amrex::ParticleReal pxout = px;
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal const ptout = pt;

--- a/src/elements/ChrUniformAcc.H
+++ b/src/elements/ChrUniformAcc.H
@@ -165,7 +165,7 @@ namespace impactx::elements
                 amrex::ParticleReal const theta = m_alpha_iez * std::log(numer / denom);
                 auto const [sin_theta, cos_theta] = amrex::Math::sincos(theta);
 
-                // intialize output values
+                // initialize output values
                 amrex::ParticleReal xout = x;
                 amrex::ParticleReal yout = y;
                 amrex::ParticleReal tout = t;
@@ -245,7 +245,7 @@ namespace impactx::elements
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
-            // compute intial value of beta*gamma
+            // compute initial value of beta*gamma
             amrex::ParticleReal const bgi = std::sqrt(std::pow(pt, 2) - 1.0_prt);
 
             // advance pt (uniform acceleration)

--- a/src/elements/ConstF.H
+++ b/src/elements/ConstF.H
@@ -145,7 +145,7 @@ namespace impactx::elements
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
 
-            // intialize output values
+            // initialize output values
             amrex::ParticleReal xout = x;
             amrex::ParticleReal yout = y;
             amrex::ParticleReal tout = t;

--- a/src/elements/Drift.H
+++ b/src/elements/Drift.H
@@ -124,7 +124,7 @@ namespace impactx::elements
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
 
-            // intialize output values
+            // initialize output values
             amrex::ParticleReal xout = x;
             amrex::ParticleReal yout = y;
             amrex::ParticleReal tout = t;

--- a/src/elements/ExactSbend.H
+++ b/src/elements/ExactSbend.H
@@ -163,7 +163,7 @@ namespace impactx::elements
             amrex::ParticleReal const yout = y;
             amrex::ParticleReal const tout = t;
 
-            // intialize output values of momenta
+            // initialize output values of momenta
             amrex::ParticleReal pxout = px;
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal ptout = pt;

--- a/src/elements/Kicker.H
+++ b/src/elements/Kicker.H
@@ -131,7 +131,7 @@ namespace impactx::elements
             amrex::ParticleReal const dpx = m_xkick * m_p_scale;
             amrex::ParticleReal const dpy = m_ykick * m_p_scale;
 
-            // intialize output values of momenta
+            // initialize output values of momenta
             amrex::ParticleReal pxout = px;
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal ptout = pt;

--- a/src/elements/Multipole.H
+++ b/src/elements/Multipole.H
@@ -139,7 +139,7 @@ namespace impactx::elements
             //amrex::ParticleReal const pt_ref = refpart.pt;
             //amrex::ParticleReal const betgam2 = std::pow(pt_ref, 2) - 1.0_prt;
 
-            // intialize output values
+            // initialize output values
             amrex::ParticleReal xout = x;
             amrex::ParticleReal yout = y;
             amrex::ParticleReal tout = t;

--- a/src/elements/NonlinearLens.H
+++ b/src/elements/NonlinearLens.H
@@ -125,7 +125,7 @@ namespace impactx::elements
             //amrex::ParticleReal const pt_ref = refpart.pt;
             //amrex::ParticleReal const betgam2 = std::pow(pt_ref, 2) - 1.0_prt;
 
-            // intialize output values
+            // initialize output values
             amrex::ParticleReal xout = x;
             amrex::ParticleReal yout = y;
             amrex::ParticleReal tout = t;

--- a/src/elements/PRot.H
+++ b/src/elements/PRot.H
@@ -116,7 +116,7 @@ namespace impactx::elements
         {
             using namespace amrex::literals; // for _rt and _prt
 
-            // intialize output values
+            // initialize output values
             amrex::ParticleReal xout = x;
             amrex::ParticleReal yout = y;
             amrex::ParticleReal tout = t;

--- a/src/elements/PlaneXYRot.H
+++ b/src/elements/PlaneXYRot.H
@@ -115,7 +115,7 @@ namespace impactx::elements
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
 
-            // intialize output values
+            // initialize output values
             amrex::ParticleReal xout = x;
             amrex::ParticleReal yout = y;
             amrex::ParticleReal tout = t;

--- a/src/elements/Quad.H
+++ b/src/elements/Quad.H
@@ -135,7 +135,7 @@ namespace impactx::elements
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
 
-            // intialize output values
+            // initialize output values
             amrex::ParticleReal xout = x;
             amrex::ParticleReal yout = y;
             amrex::ParticleReal tout = t;

--- a/src/elements/QuadEdge.H
+++ b/src/elements/QuadEdge.H
@@ -146,7 +146,7 @@ namespace impactx::elements
             amrex::ParticleReal const delta1 = std::sqrt(1_prt - 2_prt*pt/m_beta + std::pow(pt,2));
             amrex::ParticleReal a = m_a / delta1;
 
-            // intialize output values
+            // initialize output values
             amrex::ParticleReal xout = x;
             amrex::ParticleReal yout = y;
             amrex::ParticleReal tout = t;

--- a/src/elements/RFCavity.H
+++ b/src/elements/RFCavity.H
@@ -286,7 +286,7 @@ namespace RFCavityData
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
-            // compute intial value of beta*gamma
+            // compute initial value of beta*gamma
             amrex::ParticleReal const bgi = std::sqrt(std::pow(pt, 2) - 1.0_prt);
 
             // call integrator to advance (t,pt)

--- a/src/elements/Sbend.H
+++ b/src/elements/Sbend.H
@@ -153,7 +153,7 @@ namespace impactx::elements
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
 
-            // intialize output values
+            // initialize output values
             amrex::ParticleReal xout = x;
             amrex::ParticleReal yout = y;
             amrex::ParticleReal tout = t;

--- a/src/elements/ShortRF.H
+++ b/src/elements/ShortRF.H
@@ -132,7 +132,7 @@ namespace impactx::elements
             py = py * m_bgi;
             pt = pt * m_bgi;
 
-            // intialize output values
+            // initialize output values
             amrex::ParticleReal xout = x;
             amrex::ParticleReal yout = y;
             amrex::ParticleReal tout = t;
@@ -193,7 +193,7 @@ namespace impactx::elements
             using ablastr::constant::math::pi;
             amrex::ParticleReal const phi = m_phase*(pi/180.0_prt);
 
-            // compute intial value of beta*gamma
+            // compute initial value of beta*gamma
             amrex::ParticleReal const bgi = std::sqrt(std::pow(pt, 2) - 1.0_prt);
 
             // advance pt

--- a/src/elements/SoftQuad.H
+++ b/src/elements/SoftQuad.H
@@ -291,7 +291,7 @@ namespace SoftQuadrupoleData
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
-            // compute intial value of beta*gamma
+            // compute initial value of beta*gamma
             amrex::ParticleReal const bgi = std::sqrt(std::pow(pt, 2) - 1.0_prt);
 
             // call integrator to advance (t,pt)

--- a/src/elements/SoftSol.H
+++ b/src/elements/SoftSol.H
@@ -302,7 +302,7 @@ namespace SoftSolenoidData
             // length of the current slice
             amrex::ParticleReal const slice_ds = m_ds / nslice();
 
-            // compute intial value of beta*gamma
+            // compute initial value of beta*gamma
             amrex::ParticleReal const bgi = std::sqrt(std::pow(pt, 2) - 1.0_prt);
 
             // call integrator to advance (t,pt)

--- a/src/elements/Sol.H
+++ b/src/elements/Sol.H
@@ -138,7 +138,7 @@ namespace impactx::elements
             // shift due to alignment errors of the element
             shift_in(x, y, px, py);
 
-            // intialize output values
+            // initialize output values
             amrex::ParticleReal xout = x;
             amrex::ParticleReal yout = y;
             amrex::ParticleReal tout = t;

--- a/src/elements/TaperedPL.H
+++ b/src/elements/TaperedPL.H
@@ -107,7 +107,7 @@ namespace impactx::elements
                 g = m_k / refpart.rigidity_Tm();
             }
 
-            // intialize output values
+            // initialize output values
             amrex::ParticleReal xout = x;
             amrex::ParticleReal yout = y;
             amrex::ParticleReal tout = t;

--- a/src/elements/ThinDipole.H
+++ b/src/elements/ThinDipole.H
@@ -129,7 +129,7 @@ namespace impactx::elements
             amrex::ParticleReal const yout = y;
             amrex::ParticleReal const tout = t;
 
-            // intialize output values of momenta
+            // initialize output values of momenta
             amrex::ParticleReal pxout = px;
             amrex::ParticleReal pyout = py;
             amrex::ParticleReal ptout = pt;

--- a/src/python/ImpactX.cpp
+++ b/src/python/ImpactX.cpp
@@ -522,7 +522,7 @@ void init_ImpactX (py::module& m)
             py::arg("ref"), py::arg("distr"), py::arg("intensity") = py::none(),
             "Envelope tracking mode:"
             "Create a 6x6 covariance matrix from a distribution and then initialize "
-            "the the simulation for envelope tracking relative to a reference particle."
+            "the simulation for envelope tracking relative to a reference particle."
         )
         .def("add_particles", &ImpactX::add_particles,
              py::arg("bunch_charge"),

--- a/src/python/impactx/MADXParser.py
+++ b/src/python/impactx/MADXParser.py
@@ -501,7 +501,7 @@ class MADXParser:
         Combine to one list of all basic
         elements.
 
-        return a list of of element dictionaries
+        return a list of element dictionaries
         """
 
         l1 = self.__lattice[0]

--- a/src/python/impactx/MADXParser.pyi
+++ b/src/python/impactx/MADXParser.pyi
@@ -35,7 +35,7 @@ class MADXParser:
         Combine to one list of all basic
         elements.
 
-        return a list of of element dictionaries
+        return a list of element dictionaries
 
         """
     def _flatten(self, line):

--- a/src/python/impactx/impactx_pybind/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/__init__.pyi
@@ -148,7 +148,7 @@ class ImpactX:
         intensity: float | None = None,
     ) -> None:
         """
-        Envelope tracking mode:Create a 6x6 covariance matrix from a distribution and then initialize the the simulation for envelope tracking relative to a reference particle.
+        Envelope tracking mode:Create a 6x6 covariance matrix from a distribution and then initialize the simulation for envelope tracking relative to a reference particle.
         """
     def init_grids(self) -> None:
         """


### PR DESCRIPTION
## Summary
- correct typo in README
- fix TODO spelling in contribution docs
- fix repeated word occurrences
- correct several initialize/initial typos
- adjust docs and parser notes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'amrex')*

------
https://chatgpt.com/codex/tasks/task_e_683f58e8eddc8325872c565c5df17652