### PR TITLE
Fix beta formula and clarify qm units

### DIFF
--- a/docs/source/theory/concepts.rst
+++ b/docs/source/theory/concepts.rst
@@ -22,7 +22,7 @@ A reference trajectory is favorable instead of, e.g., differences to the beam ce
 The reference values of :math:`z=ct` and :math:`s` should be identical until reaching a bending element.
 (If the lattice contains no bending elements, then they should coincide.)
 Also, the reference value of :math:`ct` coincides with the value of :math:`s` in the ultrarelativistic limit.
-More generally, the derivative :math:`ds/d(ct) = \beta`, where the relativistic :math:`\beta = \sqrt{1-\frac{1}{p_t^2}}`.
+More generally, the derivative :math:`ds/d(ct) = \beta`, where the relativistic :math:`\beta = \sqrt{1-\frac{1}{\gamma^2}}`.
 
 Collective Effects
 ------------------

--- a/docs/source/usage/python.rst
+++ b/docs/source/usage/python.rst
@@ -361,7 +361,7 @@ Particles
       :param px: momentum in x
       :param py: momentum in y
       :param pt: momentum in t
-      :param qm: charge over mass in 1/eV
+      :param qm: charge over mass in Coulomb per kilogram (C/kg)
       :param bchchg: total charge within a bunch in C
 
    .. py:method:: ref_particle()

--- a/src/particles/ImpactXParticleContainer.H
+++ b/src/particles/ImpactXParticleContainer.H
@@ -50,7 +50,7 @@ namespace impactx
             px,  ///< momentum in x, scaled by the magnitude of the reference momentum [unitless] (at fixed s or t)
             py,  ///< momentum in y, scaled by the magnitude of the reference momentum [unitless] (at fixed s or t)
             pt,  ///< energy deviation, scaled by speed of light * the magnitude of the reference momentum [unitless] (at fixed s)
-            qm,  ///< charge to mass ratio, in q_e/m_e [q_e/eV]
+            qm,  ///< charge-to-mass ratio in Coulomb per kilogram (C/kg)
             w,   ///< particle weight, number of real particles represented by this macroparticle [unitless]
             nattribs ///< the number of attributes above (always last)
         };
@@ -163,7 +163,7 @@ namespace impactx
          * @param px momentum in x
          * @param py momentum in y
          * @param pt momentum in t
-         * @param qm charge over mass in 1/eV
+         * @param qm charge over mass in Coulomb per kilogram (C/kg)
          * @param bchchg total charge within a bunch in C
          */
         void

--- a/src/python/ImpactXParticleContainer.cpp
+++ b/src/python/ImpactXParticleContainer.cpp
@@ -88,7 +88,7 @@ void init_impactxparticlecontainer(py::module& m)
              ":param px: momentum in x\n"
              ":param py: momentum in y\n"
              ":param pt: momentum in t\n"
-             ":param qm: charge over mass in 1/eV\n"
+             ":param qm: charge over mass in Coulomb per kilogram (C/kg)\n"
              ":param bchchg: total charge within a bunch in C"
         )
         .def("ref_particle",

--- a/src/python/impactx/impactx_pybind/__init__.pyi
+++ b/src/python/impactx/impactx_pybind/__init__.pyi
@@ -511,7 +511,7 @@ class ImpactXParticleContainer(
         :param px: momentum in x
         :param py: momentum in y
         :param pt: momentum in t
-        :param qm: charge over mass in 1/eV
+        :param qm: charge over mass in Coulomb per kilogram (C/kg)
         :param bchchg: total charge within a bunch in C
         """
     def mean_and_std_positions(self) -> tuple[float, float, float, float, float, float]:


### PR DESCRIPTION
## Summary
- correct relativistic beta formula in theory docs
- clarify charge-to-mass ratio units in documentation and code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684107534064832595da0c9076838594